### PR TITLE
修复删除确认函错误

### DIFF
--- a/backend/controllers/ContractController.php
+++ b/backend/controllers/ContractController.php
@@ -430,6 +430,14 @@ class ContractController extends BaseController
 
         $pdf = $contract->pdf;
 
+        if(!file_exists($pdf))
+        {
+            $contract->pdf = null;
+            $contract->save();
+            
+            return $this->redirect([parent::checkUrlAccess('contract/my-view', 'contract/view'), 'id' => $id]);            
+        }
+        
         if(is_file($pdf))
         {
             unlink($pdf);


### PR DESCRIPTION
加入判断：当文件不存在，则不执行删除文件，直接清空数据库中文件路径。